### PR TITLE
Added a landed-cost folder and uploaded our calculate.json swagger file

### DIFF
--- a/landed-cost/calculate.json
+++ b/landed-cost/calculate.json
@@ -1,0 +1,1498 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "LandedCost Calculation API",
+        "description": "Landed Cost API providing duty rates, calculation, and item harmonization.\n# Basics\n### Timestamps\nTimestamps should be formatted using ISO-8601 to the nearest second, in UTC e.g `2015-06-12T09:17:37Z`\n### Expiries\nAll Requests will have an associated timestamp. The validity for any request is 1 minute to account for any clock-skew. \n# Authentication\nAll API requests must be accompanied by an API Access Key. During account provisioning, you will be issued an API Key which you must supply with every request.\n## Authorization Header\nTo pass in the Signature, set the HTTP Authorization Header: \n`authorization: avalaraapikey id:<Your Account Id> key:<Your API Key>`",
+        "version": "2.0",
+        "license": {
+            "name": "MIT",
+            "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+        }
+    },
+    "produces": [
+        "application/json"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "tags": [
+        {
+            "name": "Landed Cost Calculation API"
+        },
+        {
+            "name": "Rates API"
+        },
+        {
+            "name": "[v2]Country and Classification API"
+        },
+        {
+            "name": "[v2]Harmonized Codes API"
+        }
+    ],
+    "basePath": "/",
+    "paths": {
+        "/v3/calculate": {
+            "post": {
+                "x-swagger-router-controller": "calculate",
+                "operationId": "calculate",
+                "tags": [
+                    "Landed Cost Calculation API"
+                ],
+                "description": "Returns the fully qualified landed cost calculation for a shipment.",
+                "parameters": [
+                    {
+                        "name": "request",
+                        "in": "body",
+                        "description": "The document used to request a fully qualified landedcost calculation for a shipment.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CalculateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "Invalid request.",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "200": {
+                        "description": "Successful request.",
+                        "schema": {
+                            "$ref": "#/definitions/CalculateResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v3/rates": {
+            "post": {
+                "x-swagger-router-controller": "rates",
+                "operationId": "rates",
+                "tags": [
+                    "Landed Cost Calculation API",
+                    "Rates API"
+                ],
+                "description": "Returns rate information given an HS code, source country and destination country.",
+                "parameters": [
+                    {
+                        "name": "request",
+                        "in": "body",
+                        "description": "The document used to request rate data for a collection of hs codes.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/RatesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "Invalid request.",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "200": {
+                        "description": "Successful request.",
+                        "schema": {
+                            "$ref": "#/definitions/RatesResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v3/units": {
+            "post": {
+                "x-swagger-router-controller": "rates",
+                "operationId": "units",
+                "tags": [
+                    "Landed Cost Calculation API",
+                    "Rates API"
+                ],
+                "description": "Returns units used in all rate formulas for given HS codes.\nCan optionally be filtered by providing source and destination country codes.",
+                "parameters": [
+                    {
+                        "name": "request",
+                        "in": "body",
+                        "description": "The document used to request rate units data for a collection of hs codes.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/RatesSetupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful request.",
+                        "schema": {
+                            "$ref": "#/definitions/RatesSetupResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Invalid request.",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+
+        },
+        "/v2/countries": {
+            "get": {
+                "description": "Returns the countries we currently support, along with most common classification system for both import and export.\n No request parameters are required for this call. The method returns a full list of supported countries.",
+                "tags": [
+                    "[v2]Country and Classification API"
+                ],
+                "operationId": "Get countries listings_",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Successful request.",
+                        "schema": {
+                            "$ref": "#/definitions/GetCountriesListingsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/systems": {
+            "get": {
+                "description": "Returns a pair of classification (import and export) systems for trade between two countries",
+                "tags": [
+                    "[v2]Country and Classification API"
+                ],
+                "operationId": "Get the System for a Country_",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "source",
+                        "in": "query",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The two character ISO code for the source country."
+                    },
+                    {
+                        "name": "destination",
+                        "in": "query",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The two character ISO code for the destination country."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/GetSystemForCountryResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/browse": {
+            "get": {
+                "description": "Presents all of the available Harmonized Codes as a browesable tree. Each request specifies a parent node, and the response lists all child nodes of that parent. If no parent node is specified, all root-level nodes will be returned.",
+                "tags": [
+                    "[v2]Harmonized Codes API"
+                ],
+                "operationId": "Get_Browse HS Data_",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "system",
+                        "in": "query",
+                        "required": false,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The classification system you want to browse. Must be one of:\n* TARIC\n* SCHEDULEB\n* HTS"
+                    },
+                    {
+                        "name": "parent",
+                        "in": "query",
+                        "required": false,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The name of the parent node. Note that it is important to use the <i>name</i> of the node, as not all nodes have a harmonized code, and the code itself is different than the name."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BrowseHSDataResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/hscodes": {
+            "get": {
+                "description": "Search for Duty Rates for a harmonized code. Rates are dependant on at least a destination country.",
+                "tags": [
+                    "[v2]Harmonized Codes API"
+                ],
+                "operationId": "Get Rate Details_",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "code",
+                        "in": "query",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The harmonized code"
+                    },
+                    {
+                        "name": "system",
+                        "in": "query",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The classification system to which the code belongs"
+                    },
+                    {
+                        "name": "destination",
+                        "in": "query",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The destination country for which rate data is desired"
+                    },
+                    {
+                        "name": "source",
+                        "in": "query",
+                        "required": false,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "An optional filter for rates that limits results to a specific origin country"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GetRateDetailsResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/hscodes/{system}/{code}": {
+            "get": {
+                "description": "Allows for the traversal of classification system, harmonized codes, and duty rates, allowing the user to browse the available content.",
+                "tags": [
+                    "[v2]Harmonized Codes API"
+                ],
+                "operationId": "Get Rate Data_",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "system",
+                        "in": "path",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The classification system. If omitted, the response will be all current classification systems"
+                    },
+                    {
+                        "name": "code",
+                        "in": "path",
+                        "required": true,
+                        "x-is-map": false,
+                        "type": "string",
+                        "description": "The harmonized code within a system. If code is provided, system must also be provided"
+                    },
+                    {
+                        "name": "fullpath",
+                        "in": "query",
+                        "required": false,
+                        "x-is-map": false,
+                        "type": "boolean",
+                        "description": "If present, the response will include the entire chapter, subchapter, etc. and description data for a code"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful request.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GetRateDataResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Error": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "Friendly error response."
+                },
+                "error": {
+                    "type": "object",
+                    "description": "Full error object response."
+                }
+            },
+            "required": [
+                "message",
+                "error"
+            ]
+        },
+        "CalculateBase": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "description": "Transaction date in ISO 8601 format.",
+                    "format": "date-time"
+                },
+                "incoterms": {
+                    "type": "string",
+                    "description": "Terms of sale. Used to determine buyer obligations.",
+                    "enum": [
+                        "DAP",
+                        "DDP"
+                    ]
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceCountry",
+                    "description": "Source country of shipment."
+                },
+                "destination": {
+                    "$ref": "#/definitions/DestinationCountry",
+                    "description": "Destination country of shipment."
+                },
+                "entityType": {
+                    "type": "string",
+                    "description": "Type of sale. Can be used to determine applicable tax types.",
+                    "enum": [
+                        "B2C",
+                        "B2B"
+                    ],
+                    "example": "B2C"
+                },
+                "currency": {
+                    "$ref": "#/definitions/Currency"
+                },
+                "shipping": {
+                    "type": "object",
+                    "title": "Shipping",
+                    "properties": {
+                        "cost": {
+                            "type": "number",
+                            "description": "Cost of shipping",
+                            "format": "float",
+                            "minimum": 0,
+                            "maximum": 1000000,
+                            "example": 50
+                        },
+                        "insurance": {
+                            "type": "number",
+                            "description": "Cost of shipping insurance",
+                            "format": "float",
+                            "minimum": 0,
+                            "maximum": 1000000,
+                            "example": 50
+                        },
+                        "mode": {
+                            "type": "string",
+                            "description": "Shipping method.  Can be used to determine applicable tax types",
+                            "enum": [
+                                "ground",
+                                "air",
+                                "ocean"
+                            ],
+                            "example": "ground"
+                        },
+                        "express": {
+                            "type": "boolean",
+                            "description": "Is Shipping method.  Can be used to determine applicable tax types",
+                            "example": true
+                        },
+                        "other": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "title": "Other",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Additional shipping fee name",
+                                        "example": "US Merchandise Processing Fee"
+                                    },
+                                    "amount": {
+                                        "type": "number",
+                                        "description": "Additional shipping fee amount",
+                                        "format": "float",
+                                        "minimum": 0,
+                                        "maximum": 1000000,
+                                        "example": 1
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "amount"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "cost",
+                        "insurance",
+                        "express"
+                    ]
+                }
+            },
+            "required": [
+                "date",
+                "incoterms",
+                "source",
+                "destination",
+                "entityType",
+                "currency",
+                "shipping"
+            ]
+        },
+        "CalculateRequest": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/CalculateBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ItemRequest"
+                            }
+                        }
+                    },
+                    "required": [
+                        "items"
+                    ]
+                }
+            ]
+        },
+        "CalculateResponse": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/CalculateBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ItemResponse"
+                            }
+                        },
+                        "taxesFees": {
+                            "$ref": "#/definitions/TaxesFees"
+                        },
+                        "messages": {
+                            "$ref": "#/definitions/Messages"
+                        },
+                        "landedCost": {
+                            "type": "number",
+                            "description": "Calculated landedCost.  Total of all products and applicable taxes and fees.",
+                            "format": "float",
+                            "minimum": 0,
+                            "example": 1128
+                        },
+                        "obligations": {
+                            "type": "object",
+                            "title": "Obligations",
+                            "properties": {
+                                "buyer": {
+                                    "description": "Obligations the buyer is responsible for paying.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "Buyer",
+                                        "properties": {
+                                            "currency": {
+                                                "$ref": "#/definitions/Currency"
+                                            },
+                                            "amount": {
+                                                "type": "number",
+                                                "description": "Buyer's obligation amount",
+                                                "format": "float",
+                                                "minimum": 0,
+                                                "example": 28
+                                            }
+                                        },
+                                        "required": [
+                                            "currency",
+                                            "amount"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "buyer"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "items",
+                        "taxesFees",
+                        "messages",
+                        "landedCost",
+                        "obligations"
+                    ]
+                }
+            ]
+        },
+        "SourceCountry": {
+            "type": "object",
+            "properties": {
+                "country": {
+                    "$ref": "#/definitions/SourceCountryList"
+                },
+                "region": {
+                    "type": "string",
+                    "description": "Source region of the shipment, in <//TODO FIND ISO FORMAT> format.",
+                    "example": "BY"
+                }
+            },
+            "required": [
+                "country"
+            ]
+        },
+        "DestinationCountry": {
+            "type": "object",
+            "properties": {
+                "country": {
+                    "$ref": "#/definitions/DestinationCountryList"
+                },
+                "region": {
+                    "type": "string",
+                    "description": "Destination region of the shipment, in <//TODO FIND ISO FORMAT> format.",
+                    "example": "FL"
+                }
+            },
+            "required": [
+                "country"
+            ]
+        },
+        "SourceCountryList": {
+            "type": "string",
+            "description": "Source country of the shipment, in ISO 3166-1 alpha-2 format.",
+            "enum": [
+                "AX",
+                "AL",
+                "AD",
+                "AW",
+                "AT",
+                "BE",
+                "BM",
+                "VG",
+                "BG",
+                "CA",
+                "BQ",
+                "KY",
+                "IO",
+                "HR",
+                "CW",
+                "CY",
+                "CZ",
+                "DK",
+                "EE",
+                "FK",
+                "FI",
+                "FR",
+                "PF",
+                "TF",
+                "DE",
+                "GR",
+                "GP",
+                "GG",
+                "GF",
+                "HU",
+                "IE",
+                "IT",
+                "JP",
+                "JE",
+                "LV",
+                "LT",
+                "LU",
+                "MT",
+                "IM",
+                "MQ",
+                "YT",
+                "MC",
+                "MS",
+                "NL",
+                "NC",
+                "PN",
+                "PL",
+                "PT",
+                "RE",
+                "RO",
+                "SH",
+                "PM",
+                "SM",
+                "SK",
+                "SI",
+                "ES",
+                "SE",
+                "TK",
+                "TC",
+                "GB",
+                "US",
+                "WF"
+            ],
+            "example": "DE"
+        },
+        "DestinationCountryList": {
+            "type": "string",
+            "description": "Destination country of the shipment, in ISO 3166-1 alpha-2 format.",
+            "enum": [
+                "AX",
+                "AL",
+                "AD",
+                "AW",
+                "AU",
+                "AT",
+                "BE",
+                "BM",
+                "VG",
+                "BG",
+                "CA",
+                "BQ",
+                "KY",
+                "IO",
+                "CX",
+                "CC",
+                "HR",
+                "CW",
+                "CY",
+                "CZ",
+                "DK",
+                "EE",
+                "FK",
+                "FI",
+                "FR",
+                "PF",
+                "TF",
+                "DE",
+                "GR",
+                "GP",
+                "GG",
+                "GF",
+                "HU",
+                "IE",
+                "IT",
+                "JP",
+                "JE",
+                "LV",
+                "LT",
+                "LU",
+                "MT",
+                "IM",
+                "MQ",
+                "YT",
+                "MC",
+                "MS",
+                "NL",
+                "NC",
+                "NF",
+                "PN",
+                "PL",
+                "PT",
+                "RE",
+                "RO",
+                "SH",
+                "PM",
+                "SM",
+                "SG",
+                "SK",
+                "SI",
+                "ES",
+                "SE",
+                "TK",
+                "TC",
+                "GB",
+                "US",
+                "WF"
+            ],
+            "example": "US"
+        },
+        "Currency": {
+            "type": "string",
+            "description": "Currency, in ISO 4217 format.",
+            "enum": [
+                "AED",
+                "AFN",
+                "ALL",
+                "AMD",
+                "ANG",
+                "AOA",
+                "ARS",
+                "AUD",
+                "AWG",
+                "AZN",
+                "BAM",
+                "BBD",
+                "BDT",
+                "BGN",
+                "BHD",
+                "BIF",
+                "BMD",
+                "BND",
+                "BOB",
+                "BRL",
+                "BSD",
+                "BTC",
+                "BTN",
+                "BWP",
+                "BYR",
+                "BZD",
+                "CAD",
+                "CDF",
+                "CHF",
+                "CLF",
+                "CLP",
+                "CNY",
+                "COP",
+                "CRC",
+                "CUC",
+                "CUP",
+                "CVE",
+                "CZK",
+                "DJF",
+                "DKK",
+                "DOP",
+                "DZD",
+                "EEK",
+                "EGP",
+                "ERN",
+                "ETB",
+                "EUR",
+                "FJD",
+                "FKP",
+                "GBP",
+                "GEL",
+                "GGP",
+                "GHS",
+                "GIP",
+                "GMD",
+                "GNF",
+                "GTQ",
+                "GYD",
+                "HKD",
+                "HNL",
+                "HRK",
+                "HTG",
+                "HUF",
+                "IDR",
+                "ILS",
+                "IMP",
+                "INR",
+                "IQD",
+                "IRR",
+                "ISK",
+                "JEP",
+                "JMD",
+                "JOD",
+                "JPY",
+                "KES",
+                "KGS",
+                "KHR",
+                "KMF",
+                "KPW",
+                "KRW",
+                "KWD",
+                "KYD",
+                "KZT",
+                "LAK",
+                "LBP",
+                "LKR",
+                "LRD",
+                "LSL",
+                "LTL",
+                "LVL",
+                "LYD",
+                "MAD",
+                "MDL",
+                "MGA",
+                "MKD",
+                "MMK",
+                "MNT",
+                "MOP",
+                "MRO",
+                "MTL",
+                "MUR",
+                "MVR",
+                "MWK",
+                "MXN",
+                "MYR",
+                "MZN",
+                "NAD",
+                "NGN",
+                "NIO",
+                "NOK",
+                "NPR",
+                "NZD",
+                "OMR",
+                "PAB",
+                "PEN",
+                "PGK",
+                "PHP",
+                "PKR",
+                "PLN",
+                "PYG",
+                "QAR",
+                "RON",
+                "RSD",
+                "RUB",
+                "RWF",
+                "SAR",
+                "SBD",
+                "SCR",
+                "SDG",
+                "SEK",
+                "SGD",
+                "SHP",
+                "SLL",
+                "SOS",
+                "SRD",
+                "STD",
+                "SVC",
+                "SYP",
+                "SZL",
+                "THB",
+                "TJS",
+                "TMT",
+                "TND",
+                "TOP",
+                "TRY",
+                "TTD",
+                "TWD",
+                "TZS",
+                "UAH",
+                "UGX",
+                "USD",
+                "UYU",
+                "UZS",
+                "VEF",
+                "VND",
+                "VUV",
+                "WST",
+                "XAF",
+                "XAG",
+                "XAU",
+                "XCD",
+                "XDR",
+                "XOF",
+                "XPD",
+                "XPF",
+                "XPT",
+                "YER",
+                "ZAR",
+                "ZMK",
+                "ZMW",
+                "ZWL"
+            ],
+            "example": "USD"
+        },
+        "ItemRequest": {
+            "type": "object",
+            "properties": {
+                "lineNumber": {
+                    "type": "string",
+                    "description": "Transaction line number.",
+                    "example": "1"
+                },
+                "hsCode": {
+                    "type": "string",
+                    "description": "The harmonized classification code of the product.",
+                    "example": "930700"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Description of the product.",
+                    "example": "Swords"
+                },
+                "price": {
+                    "type": "number",
+                    "description": "Item price of the product.",
+                    "format": "float",
+                    "minimum": 0,
+                    "maximum": 1000000,
+                    "example": 100
+                },
+                "quantity": {
+                    "type": "number",
+                    "description": "Quantity of the item shipped.",
+                    "format": "float",
+                    "minimum": 1,
+                    "maximum": 1000000,
+                    "example": 10
+                },
+                "extendedPrice": {
+                    "type": "number",
+                    "description": "Extended price (price * quantity) of the item shipped.",
+                    "format": "float",
+                    "minimum": 0,
+                    "maximum": 1000000000000
+                },
+                "units": {
+                    "type": "array",
+                    "description": "Collection of units of measure used to calculate applicable taxes and fees",
+                    "items": {
+                        "type": "object",
+                        "title": "Unit",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the unit of measure.",
+                                "example": "kg"
+                            },
+                            "amount": {
+                                "type": "number",
+                                "description": "Value associated with this unit of measure.",
+                                "format": "float",
+                                "minimum": 0,
+                                "maximum": 1000000,
+                                "example": 10
+                            },
+                            "total": {
+                                "type": "number",
+                                "description": "Total value associated with this unit of measure (amount * quantity).",
+                                "format": "float",
+                                "minimum": 0,
+                                "maximum": 1000000000000,
+                                "example": 10
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "lineNumber",
+                "hsCode",
+                "description"
+            ]
+        },
+        "ItemResponse": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ItemRequest"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "messages": {
+                            "$ref": "#/definitions/Messages"
+                        },
+                        "taxesFees": {
+                            "$ref": "#/definitions/TaxesFees"
+                        }
+                    },
+                    "required": [
+                        "messages",
+                        "taxesFees"
+                    ]
+                }
+            ]
+        },
+        "Messages": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "Special messages that apply.",
+                "example": "Shipment meets US import duty de minimis threshold. Therefore, import duty applies."
+            }
+        },
+        "TaxesFees": {
+            "type": "object",
+            "properties": {
+                "duty": {
+                    "type": "number",
+                    "description": "Calculated customs duty.",
+                    "format": "float",
+                    "minimum": 0,
+                    "example": 27
+                },
+                "vat": {
+                    "type": "number",
+                    "description": "Calculated iVAT",
+                    "format": "float",
+                    "minimum": 0,
+                    "example": 0
+                },
+                "other": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "Other",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Other calculated tax or fee name.",
+                                "example": "US Merchandise Processing Fee"
+                            },
+                            "amount": {
+                                "type": "number",
+                                "description": "Other calculated tax or fee amount.",
+                                "format": "float",
+                                "minimum": 0,
+                                "example": 1
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "amount"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "duty",
+                "vat",
+                "other"
+            ]
+        },
+        "RatesRequest": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/RateRequestObj"
+            }
+        },
+        "RateRequestObj": {
+            "type": "object",
+            "properties": {
+                "hsCode": {
+                    "type": "string",
+                    "description": "The harmonized classification code of the product",
+                    "example": "930700"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceCountryList",
+                    "description": "The source country used to determine system and further filter the rate response",
+                    "example": "DE"
+                },
+                "destination": {
+                    "$ref": "#/definitions/DestinationCountryList",
+                    "description": "The destination country used to determine system and further filter the rate response",
+                    "example": "US"
+                }
+            },
+            "required": [
+                "hsCode",
+                "source",
+                "destination"
+            ]
+        },
+        "RatesResponse": {
+            "$ref": "#/definitions/RateResponseObj"
+        },
+        "RateObj": {
+            "type": "object",
+            "properties": {
+                "rate": {
+                    "type": "string",
+                    "description": "The rate as written in the source material",
+                    "example": "2.7%"
+                },
+                "currency": {
+                    "$ref": "#/definitions/Currency"
+                },
+                "taxSection": {
+                    "type": "string",
+                    "description": "The tax section the rate applies to",
+                    "example": "Import Duty"
+                },
+                "unit": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "MeasurementUnit",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The unit of measure of the rate formula",
+                                "example": "kg"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "rate",
+                "currency",
+                "taxSection"
+            ]
+        },
+        "RateResponseObj": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "ResponseObj",
+                "properties": {
+                    "hsCode": {
+                        "type": "string",
+                        "description": "The harmonized classification code of the product",
+                        "example": "930700"
+                    },
+                    "source": {
+                        "$ref": "#/definitions/SourceCountryList",
+                        "description": "The source country used to determine system and further filter the rate response",
+                        "example": "DE"
+                    },
+                    "destination": {
+                        "$ref": "#/definitions/DestinationCountryList",
+                        "description": "The destination country used to determine system and further filter the rate response",
+                        "example": "US"
+                    },
+                    "rates": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/RateObj"
+                        }
+                    }
+                },
+                "required": [
+                    "hsCode",
+                    "source",
+                    "destination",
+                    "rates"
+                ]
+            }
+        },
+        "RatesSetupRequest": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/RateSetupRequestObj"
+            }
+        },
+        "RateSetupRequestObj": {
+            "type": "object",
+            "properties": {
+                "hsCode": {
+                    "type": "string",
+                    "description": "The harmonized classification code of the product.",
+                    "example": "01022940"
+                },
+                "source": {
+                    "$ref": "#/definitions/SourceCountryList",
+                    "description": "The source country used to determine system and further filter the rate response",
+                    "example": "DE"
+                },
+                "destination": {
+                    "$ref": "#/definitions/DestinationCountryList",
+                    "description": "The destination country used to determine system and further filter the rate response",
+                    "example": "US"
+                }
+            },
+            "required": [
+                "hsCode"
+            ]
+        },
+        "RatesSetupResponse": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "ResponseObj",
+                "properties": {
+                            "hsCode": {
+                                "type": "string",
+                                "description": "The harmonized classification code of the product.",
+                                "example": "01022940"
+                            },
+                            "source": {
+                                "$ref": "#/definitions/SourceCountryList",
+                                "description": "The source country used to determine system and further filter the rate response",
+                                "example": "DE"
+                            },
+                            "destination": {
+                                "$ref": "#/definitions/DestinationCountryList",
+                                "description": "The destination country used to determine system and further filter the rate response",
+                                "example": "US"
+                            },
+                            "units": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "description": "Units used in rate formulas for a given hs code.",
+                                    "example": "kg"
+                                }
+                            }
+                        },
+                        "required": [
+                            "units"
+                        ]
+            }
+        },
+        "GetCountriesListingsResponse": {
+            "title": "Get countries listings response",
+            "type": "object",
+            "properties": {
+                "destination": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "Country",
+                        "properties": {
+                            "code": {
+                                "$ref": "#/definitions/DestinationCountryList"
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "The United States"
+                            },
+                            "system": {
+                                "type": "string",
+                                "example": "HTS"
+                            }
+                        }
+
+                    }
+                },
+                "source": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "Country",
+                        "properties": {
+                            "code": {
+                                "$ref": "#/definitions/DestinationCountryList"
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "The United States"
+                            },
+                            "system": {
+                                "type": "string",
+                                "example": "HTS"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "destination",
+                "source"
+            ]
+        },
+        "GetSystemForCountryResponse": {
+            "title": "Get the System for a Country response",
+            "type": "object",
+            "properties": {
+                "export": {
+                    "type": "object",
+                    "description": "The system of export classification between the source and destination countries specified",
+                    "title": "Export",
+                    "properties": {
+                        "system": {
+                            "type": "string",
+                            "example": "SCHEDULEB",
+                            "description": "The classification system. Must be one of:\n* TARIC\n* SCHEDULEB\n* HTS"
+                        }
+                    }
+                },
+                "import": {
+                    "type": "object",
+                    "description": "The system of import classification between the source and destination countries specified",
+                    "title": "Import",
+                    "properties": {
+                        "system": {
+                            "type": "string",
+                            "example": "TARIC",
+                            "description": "The classification system. Must be one of:\n* TARIC\n* SCHEDULEB\n* HTS"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "export",
+                "import"
+            ]
+        },
+        "BrowseHSDataResponse": {
+            "title": "Browse HS Data response",
+            "type": "object",
+            "properties": {
+                "hsCode": {
+                    "type": "string",
+                    "example": "9301",
+                    "description": "The harmonized code"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Military weapons, other than revolvers, pistols and the arms of heading 9307",
+                    "description": "The human-readable description of the classification"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "HS_9302",
+                    "description": "The name of the node; this can be used to find the child nodes"
+                }
+            },
+            "required": [
+                "hsCode",
+                "description",
+                "name"
+            ]
+        },
+        "GetRateDetailsResponse": {
+            "title": "Get Rate Details response",
+            "type": "object",
+            "properties": {
+                "hsCode": {
+                    "type": "string",
+                    "example": "9307000000"
+                },
+                "system": {
+                    "type": "string",
+                    "example": "HTS"
+                },
+                "codePath": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "CodePath",
+                        "properties": {
+                            "hsCode": {
+                                "type": "string",
+                                "description": "The harmonized code",
+                                "example": "93"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Harmonized code description",
+                                "example": "ARMS AND AMMUNITION; PARTS AND ACCESSORIES THEREOF"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "A concatenation of the system and harmonized code: `<system>_<harmonizedCode>`",
+                                "example": "HS_93"
+                            }
+                        }
+                    }
+                },
+                "rates": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "Rate",
+                        "properties": {
+                            "sourceCountry": {
+                                "type": "string",
+                                "description": "The two-character ISO code identifying the origin country associated with the duty",
+                                "example": "`null`"
+                            },
+                            "formula": {
+                                "type": "string",
+                                "description": "The formula used to calculate the rate, presented in Avalara-specific format",
+                                "example": "rate(2.7%,costbasis())"
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "There are three types of landed cost rates that may be returned.\n * ad valorem: this rate applies to the declared `customs-value` This is typically represented as a percentage of the cost.\n * units: this is a rate that is tied to unit of meaure. This is typically expressed as a monetary value per quantity, such as: $1/kg\n * unknown: there is no stored rate data (or no applicable taxes) for the specified combination. Note that these will always have `\"formula\": \"notax()\"",
+                                "example": "ad valorem"
+                            },
+                            "unit": {
+                                "type": "string",
+                                "description": "If the rate is assessed at a unit level, the appropriate unit involved. If `type` is not `units`, this value will be an empty string.",
+                                "example": ""
+
+                            },
+                            "raw": {
+                                "type": "string",
+                                "description": "The human-readable version of the rate.",
+                                "example": "2.7% (Cost)"
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "The three-character ISO code for the currency in which the duty should be assessed.",
+                                "example": "USD"
+                            },
+                            "required": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "description": "The required input values to calculate the correct duty amount.",
+                                    "example": "value"
+                                }
+                            },
+                            "customsValue": {
+                                "type": "string",
+                                "description": "The customs value describes how to apply the duty rate. There are two current types\n * fob\n * cif",
+                                "example": "fob"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "hsCode",
+                "system",
+                "codePath",
+                "rates"
+            ]
+        },
+        "GetRateDataResponse": {
+            "title": "Get Rate Data response",
+            "type": "object",
+            "description": "Array of rate information by source country, formatted as for retrieval for Duty Rate retrieval",
+            "properties": {
+                "hsCode": {
+                    "type": "string",
+                    "description": "The harmonized code",
+                    "example": "5703201000"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A concatenation of the system and harmonized code: `<system>_<harmonizedCode>`",
+                    "example": "HTS_5703201000"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A description of the harmonized code classification",
+                    "example": "Hand-hooked, that is, in which the tufts were inserted by hand or by means of a hand tool"
+                }
+            },
+            "required": [
+                "hsCode",
+                "name",
+                "description"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
If possible we'd like to put the routes tagged with '[v2]' below our newer ones (Landed Cost Calculation API and Rates API) in the production documentation.

Thanks!