### PR TITLE
Updating calc response definition to support NOT cross-border response

### DIFF
--- a/landed-cost/calculate.json
+++ b/landed-cost/calculate.json
@@ -1226,8 +1226,6 @@
                             },
                             "required": [
                                 "amount",
-                                "details",
-                                "obligations",
                                 "messages"
                             ]
                         },


### PR DESCRIPTION
Removing required flag for calc response landedCost.details and landedCost.obligations, as these are not returned for shipments that are NOT cross-border.